### PR TITLE
Add ABACUS architecture, runtime, integration, and gap documentation plus recursive-hook task

### DIFF
--- a/ABACUS_DEPLOYMENT_STATUS.md
+++ b/ABACUS_DEPLOYMENT_STATUS.md
@@ -1,0 +1,44 @@
+# ABACUS Deployment Status
+
+Date: 2026-06-11
+
+## Status definitions
+
+- **Active:** workflow file is directly under `.github/workflows/` and has an `on:` trigger.
+- **Disabled / pending:** workflow file is outside `.github/workflows/`, such as `.github/workflows-pending/`.
+- **Deprecated:** workflow file is retained under `.github/workflows/legacy/` or superseded by an active workflow.
+
+## Deployment, release, pages, and artifact workflows
+
+| Workflow | Trigger | Active | Purpose |
+| -------- | ------- | ------ | ------- |
+| `.github/workflows/cd.yml` | `push`, `pull_request`, daily `schedule`, `workflow_dispatch` | Yes | DMAIC V3.3 CD pipeline; runs `DMAIC_V3.dmaic_v3_engine`, builds book/GLOOB artifacts, and uploads CD artifacts. |
+| `.github/workflows/cd-unified.yml` | `push`, tag push, `pull_request`, daily `schedule`, `workflow_dispatch` | Yes | Unified DOW + Recursive DMAIC CD with lint, CI, DMAIC full cycle, artifact build, and release jobs. |
+| `.github/workflows/deployment-enforcement.yml` | `workflow_dispatch` with environment input | Yes | DELTA_1 deployment governance gates for dev/stage/prod. |
+| `.github/workflows/delta-1-deploy.yml` | `workflow_dispatch` | Yes | DELTA_1 deployment scaffold/workflow. |
+| `.github/workflows/dow-main-cicd.yml` | `pull_request`, `push`, six-hour `schedule` | Yes | DOW main CI/CD; runs tests and `DMAIC_V3/full_pipeline_orchestrator.py`. |
+| `.github/workflows/dow-scheduled.yml` | six-hour `schedule`, `workflow_dispatch` | Yes | Scheduled DOW pipeline execution; uploads execution logs. |
+| `.github/workflows/gbogeb-abacus-integration-ci-cd.yml` | `push`, `pull_request`, `workflow_dispatch` | Yes, but path-stale | GBOGEB/ABACUS ↔ DOW integration; references root-level bridge files that do not match the located `staging/` bridge path. |
+| `.github/workflows/release.yml` | tag push `v*`, `workflow_dispatch` | Yes | Release and package workflow with `contents: write` and Pages permissions. |
+| `.github/workflows/delta-1-release.yml` | `workflow_dispatch` | Yes | DELTA_1 release workflow scaffold. |
+| `.github/workflows/pages.yml` | `push` to `main` with runtime/pages paths, `workflow_dispatch` | Yes | QPLANT Pages runtime publish using Pages artifact upload/deploy actions. |
+| `.github/workflows/deploy-docs.yml` | `push` to `main` for docs/dashboard paths, `workflow_dispatch` | Yes | Documentation deployment to GitHub Pages. |
+| `.github/workflows/book-build.yml` | Markdown/book/script `push`, `pull_request`, `workflow_dispatch` | Yes | Builds DMAIC V3 book and uploads artifacts. |
+| `.github/workflows/export-docs.yml` | docs/global index `push`, `workflow_dispatch` | Yes | Exports docs artifacts. |
+| `.github/workflows/reports.yml` | daily `schedule`, `workflow_dispatch`, selected `push` | Yes | Generates and uploads project reports. |
+| `.github/workflows/dmaic-commit-metrics.yml` | `push`, docs deploy `workflow_run`, `workflow_dispatch` | Yes | Per-commit metrics and post-deploy signal collection. |
+| `.github/workflows/inventory.yml` | weekly `schedule`, `workflow_dispatch` | Yes | Repository inventory and audit artifacts. |
+| `.github/workflows/review-artifact-validation.yml` | selected docs/SSOT `push` | Yes | Review artifact validation. |
+| `.github/workflows/runtime-verification.yml` | `workflow_dispatch`, successful deployment enforcement `workflow_run` | Yes | Runtime readiness verification after deployment enforcement. |
+| `.github/workflows/runtime-governance.yml` | `workflow_dispatch` | Yes | Runtime governance validation scaffold. |
+| `.github/workflows/legacy/cd.yml.old` | legacy `on:` block retained in `.old` file | No | Deprecated CD workflow superseded by active `.github/workflows/cd.yml`. |
+| `.github/workflows/legacy/dow-integration-ci-cd.yml.old` | legacy file under `.github/workflows/legacy/` | No | Deprecated DOW integration CI/CD workflow. |
+| `.github/workflows-pending/deploy-docs.yml` | pending copy outside active workflow directory | No | Pending/disabled docs deploy copy. |
+| `.github/workflows-pending/release.yml` | pending copy outside active workflow directory | No | Pending/disabled release copy. |
+| `.github/workflows-pending/dashboard-health.yml` | pending copy outside active workflow directory | No | Pending/disabled dashboard health copy. |
+| `DMAIC_V3/.github/workflows/cd-main.yml` | nested workflow path | Not active at repo root | DMAIC_V3 nested CD lineage; not counted as root GitHub Actions execution. |
+| `DMAIC_V3/.github/workflows/release.yml` | nested workflow path | Not active at repo root | DMAIC_V3 nested release lineage; not counted as root GitHub Actions execution. |
+
+## Active workflow summary
+
+The active deployment surface is complete but overlapping: root workflows cover CD, release, Pages, reports/artifacts, DOW scheduled execution, and runtime verification. Deprecated workflows are isolated under `.github/workflows/legacy/`. Pending workflows are outside the active `.github/workflows/` directory. The only deployment blocker identified here is path drift in `gbogeb-abacus-integration-ci-cd.yml`.

--- a/ABACUS_EXECUTION_BACKLOG.md
+++ b/ABACUS_EXECUTION_BACKLOG.md
@@ -1,0 +1,106 @@
+# ABACUS Execution Backlog
+
+Date: 2026-06-11
+
+## Backlog rules
+
+- No new orchestrators.
+- No duplicate registries.
+- No duplicate integration layers.
+- Each item must close or validate an evidence-backed gap from lineage, runtime inventory, integration matrix, or deployment status.
+
+## P0 — Runtime SSOT selection and integration completion
+
+### P0-1 — Publish Runtime SSOT decision
+
+- **Description:** Treat `DMAIC_V3/core/twelve_cluster_orchestrator.py` / `TwelveClusterOrchestrator` as the runtime governance SSOT and document `DMAIC_V3/full_pipeline_orchestrator.py` as secondary operational phase runner plus `local_mcp/agent_orchestrator_v3.0.py` as V2.3 compatibility runtime.
+- **Evidence:** README canonical orchestrator section names `DMAIC_V3/core/twelve_cluster_orchestrator.py` canonical and `local_mcp/agent_orchestrator_v3.0.py` compatibility; tests import and validate `TwelveClusterOrchestrator`; active DOW workflows still invoke `full_pipeline_orchestrator.py`.
+- **Owner:** Runtime governance / DMAIC_V3 maintainers.
+- **Dependency:** `ABACUS_EXECUTION_BASELINE.md` accepted.
+- **Acceptance Criteria:** SSOT decision appears in README or governance docs; no new orchestrator files are added; workflow owners acknowledge secondary entrypoints.
+
+### P0-2 — Reconcile GBOGEB bridge workflow paths
+
+- **Description:** Align `.github/workflows/gbogeb-abacus-integration-ci-cd.yml` with the located bridge implementation under `staging/` or deliberately promote the staging implementation and matching tests/config to the root paths expected by the workflow.
+- **Evidence:** Workflow references `GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`, `test_integration_bridge.py`, and `UNIFIED_GLOB_CONFIG.yaml`; repository evidence locates `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`.
+- **Owner:** GBOGEB integration owner / CI owner.
+- **Dependency:** P0-1 SSOT decision; no duplicate bridge creation.
+- **Acceptance Criteria:** Workflow file existence checks pass against actual repository paths; bridge import commands use the selected path; `ABACUS_DEPLOYMENT_STATUS.md` no longer marks the workflow path-stale.
+
+### P0-3 — Normalize KEB/GBOGEB imports across runtime consumers
+
+- **Description:** Establish a single import pattern for `KEB` and `GBOGEB` so `KnowledgeIntegrationV23` and `TwelveClusterOrchestrator` consume the same implementation paths.
+- **Evidence:** `KnowledgeIntegrationV23` imports `core.keb.keb.KEB` and `core.gbogeb.gbogeb.GBOGEB`; `TwelveClusterOrchestrator` currently imports top-level `keb` and `gbogeb` after path insertion.
+- **Owner:** Runtime integration owner.
+- **Dependency:** P0-1 SSOT decision.
+- **Acceptance Criteria:** Both runtime consumers import the same implementation modules; tests cover `TwelveClusterOrchestrator(use_keb=True, use_gbogeb=True)` or a documented fallback; no new KEB/GBOGEB implementation files are introduced.
+
+## P1 — Recursive parity closure and registry alignment
+
+### P1-1 — Close recursive hook retrieval parity
+
+- **Description:** Resolve the missing V2.2 `get_recursive_hooks(enabled_only=True)` parity through a lightweight read utility or documented query path over existing artifact-level `recursive_hooks` metadata.
+- **Evidence:** `PHASE_B_RECURSIVE_HOOKS_PARITY_AUDIT_V4.4.0.md` marks dedicated retrieval API as missing; `V2.2_RECURSIVE_HOOKS_VERSION_ALIGNMENT.md` documents the historical retrieval function; `DOWRecursiveHooksInjector` already writes artifact-level `recursive_hooks`.
+- **Owner:** Runtime governance / DMAIC_V3 maintainers.
+- **Dependency:** `tracking_v2.3/tasks/TASK_recursive_hook_parity.yaml`.
+- **Acceptance Criteria:** Retrieval path is implemented or documented; it reads existing `recursive_hooks` artifacts; validation covers at least one artifact; `DOWRecursiveHooksInjector` remains the source of recursive metadata.
+
+### P1-2 — Align runtime registry terminology
+
+- **Description:** Document `runtime/manifests/runtime-topology.yaml` as runtime/deployment topology SSOT and distinguish it from generated/evidence registries such as `metrics/federation/runtime_registry.json` and `reports/runtime_registry_report.json`.
+- **Evidence:** Runtime topology manifest declares runtime repository, governance repository, capabilities, and protected environments; metrics/report JSON files contain evidence/coverage outputs.
+- **Owner:** Runtime governance owner.
+- **Dependency:** P0-1 SSOT decision.
+- **Acceptance Criteria:** Registry docs define topology SSOT versus evidence outputs; no duplicate runtime registry is created; references in execution docs use the same terminology.
+
+### P1-3 — Validate phase execution workflow argument compatibility
+
+- **Description:** Review `.github/workflows/dmaic-phase-execution.yml` because it passes `--phase` to `DMAIC_V3/full_pipeline_orchestrator.py`, while the full pipeline parser evidence lists `--iteration`, `--no-idempotency`, `--no-git`, `--quiet`, and `--debug-port` but not `--phase`.
+- **Evidence:** `.github/workflows/dmaic-phase-execution.yml` executes `python DMAIC_V3/full_pipeline_orchestrator.py --phase ...`; `DMAIC_V3/full_pipeline_orchestrator.py` parser does not define `--phase`; `DMAIC_V3/dmaic_v3_engine.py` parser does define `--phase`.
+- **Owner:** CI owner / DMAIC runtime owner.
+- **Dependency:** P0-1 SSOT decision.
+- **Acceptance Criteria:** Workflow command targets an entrypoint that supports `--phase` or command arguments are corrected; validation command is documented; no new phase runner is created.
+
+## P2 — Dashboard generation and metrics collection
+
+### P2-1 — Preserve deployment and runtime dashboards from existing workflows
+
+- **Description:** Keep dashboard/report generation on existing workflows (`dashboard-health`, `reports`, `dmaic-commit-metrics`, Pages workflows) and avoid adding a new dashboard pipeline until current outputs are inventoried.
+- **Evidence:** `.github/workflows/dashboard-health.yml`, `.github/workflows/reports.yml`, `.github/workflows/dmaic-commit-metrics.yml`, `.github/workflows/pages.yml`, and `.github/workflows/deploy-docs.yml` are active root workflows.
+- **Owner:** Documentation/dashboard owner.
+- **Dependency:** P1-2 registry terminology.
+- **Acceptance Criteria:** Existing dashboard/report outputs are listed; no duplicate dashboard workflow is introduced; missing dashboard outputs are tracked as tasks rather than implemented ad hoc.
+
+### P2-2 — Consolidate metric emission ownership
+
+- **Description:** Define whether GBOGEB metrics, DMAIC metrics, or workflow artifacts are the authoritative metrics source for each dashboard/report use case.
+- **Evidence:** `GBOGEB.collect_metric` records agent metrics; `KnowledgeIntegrationV23.collect_agent_metric` routes metrics to GBOGEB; `.github/workflows/dmaic-commit-metrics.yml` generates per-commit metrics; reports workflows upload generated reports.
+- **Owner:** Metrics owner / GBOGEB owner.
+- **Dependency:** P0-3 import/consumption normalization.
+- **Acceptance Criteria:** Metrics sources are mapped by use case; duplicate metrics stores are not introduced; GBOGEB remains the governance metrics implementation where agent metrics are needed.
+
+## P3 — Optional enhancements
+
+### P3-1 — Add developer-facing runtime invocation guide
+
+- **Description:** Add a concise guide explaining when to invoke `TwelveClusterOrchestrator`, `FullPipelineOrchestrator`, `DMAIC_V3.dmaic_v3_engine`, and `AgentOrchestratorV3`.
+- **Evidence:** Current evidence shows multiple valid invocation paths across README, workflows, and handover docs; confusion risks duplicate orchestration work.
+- **Owner:** Documentation owner.
+- **Dependency:** P0-1 through P1-3 completed or accepted.
+- **Acceptance Criteria:** Guide lists each entrypoint, status, command, owner, and non-goals; no new runtime code is added.
+
+### P3-2 — Archive or label duplicate full-pipeline variants
+
+- **Description:** Decide archival labels for `full_pipeline_orchestrator_clean.py`, `full_pipeline_orchestrator_corrupted.py`, and `full_pipeline_orchestrator_fixed.py` without changing the active `DMAIC_V3/full_pipeline_orchestrator.py` runtime.
+- **Evidence:** Existing implementation logs and deprecation notices identify duplicate/corrupted/fixed full-pipeline copies; active workflows reference `DMAIC_V3/full_pipeline_orchestrator.py`.
+- **Owner:** Repository maintenance owner.
+- **Dependency:** P0-1 SSOT decision.
+- **Acceptance Criteria:** Duplicate files are documented as archived/deprecated or moved through an approved cleanup PR; active workflows remain pointed at the selected operational runtime.
+
+### P3-3 — Expand integration smoke tests after path/import consolidation
+
+- **Description:** Add smoke tests only after P0 path/import consolidation to cover KEB/GBOGEB enabled initialization and GBOGEB bridge workflow path assumptions.
+- **Evidence:** Current tests cover `TwelveClusterOrchestrator(use_keb=False, use_gbogeb=False)`; runtime code includes enabled paths for KEB/GBOGEB; GBOGEB workflow path drift is known.
+- **Owner:** Test owner / runtime integration owner.
+- **Dependency:** P0-2 and P0-3.
+- **Acceptance Criteria:** Tests cover enabled integration paths; no duplicate test harness creates alternate runtime semantics; failures produce actionable path/import fixes.

--- a/ABACUS_EXECUTION_BASELINE.md
+++ b/ABACUS_EXECUTION_BASELINE.md
@@ -1,0 +1,139 @@
+# ABACUS Execution Baseline
+
+Date: 2026-06-11
+
+## Purpose
+
+This baseline converts the validated lineage findings into runtime ownership and execution governance. It does not create new architecture, new orchestrators, duplicate registries, or duplicate integration layers.
+
+## Runtime SSOT
+
+**Selected orchestrator:** `DMAIC_V3/core/twelve_cluster_orchestrator.py` / `TwelveClusterOrchestrator`.
+
+**Status:** Active SSOT for runtime governance and canonical 12-cluster execution.
+
+**Justification:**
+
+- `README.md` explicitly declares `DMAIC_V3/core/twelve_cluster_orchestrator.py` as the canonical orchestrator path and `local_mcp/agent_orchestrator_v3.0.py` as compatibility wrapper.
+- `TwelveClusterOrchestrator` is named "Canonical 12-Cluster Orchestrator V3.0 for DMAIC" in the module docstring.
+- `TwelveClusterOrchestrator` owns the cluster contract, phase sequence, KEB/GBOGEB optional initialization, temporal event capture, phase parallel execution, phase hook execution, and report generation.
+- `DMAIC_V3/tests/test_twelve_cluster_orchestrator.py` directly tests the canonical 12-cluster contract, parallel execution, temporal hooks, run scoping, failed phase behavior, and timeout enforcement.
+
+**Evidence:**
+
+- `README.md`: canonical orchestrator section maps canonical path to `DMAIC_V3/core/twelve_cluster_orchestrator.py` and compatibility wrapper to `local_mcp/agent_orchestrator_v3.0.py`.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py`: module docstring, `TwelveClusterOrchestrator`, `CLUSTER_CONTRACT`, `PHASE_SEQUENCE`, KEB/GBOGEB initialization, `run_phases_with_hooks`, and `generate_report`.
+- `DMAIC_V3/tests/test_twelve_cluster_orchestrator.py`: coverage for contract, temporal hooks, and timeout behavior.
+
+### Runtime authority table
+
+| Runtime | Status | References | Recommendation |
+| -------------------- | ------ | ---------- | -------------- |
+| Active SSOT: `DMAIC_V3/core/twelve_cluster_orchestrator.py` / `TwelveClusterOrchestrator` | Active SSOT | `README.md` canonical path; `docs_versioned/v2.3/migration/to_v33.md` names it central; direct tests in `DMAIC_V3/tests/test_twelve_cluster_orchestrator.py`; optional KEB/GBOGEB runtime initialization. | Retain as governance SSOT; do not create a new orchestrator. |
+| Secondary Runtime: `DMAIC_V3/full_pipeline_orchestrator.py` / `FullPipelineOrchestrator` | Secondary operational runtime | Active DOW workflows run it; deployment docs use it; it imports and executes phase modules 0-9. | Retain as operational phase-runner until a later consolidation task aligns workflow entrypoints with the 12-cluster SSOT. |
+| Legacy Runtime: `local_mcp/agent_orchestrator_v3.0.py` / `AgentOrchestratorV3` | Compatibility / V2.3 lineage runtime | README labels it compatibility wrapper; V2.3 CI workflow executes it; it loads six V2.3 optimized agents and `KnowledgeIntegrationV23`. | Retain for compatibility and agent tests; do not promote it above 12-cluster SSOT. |
+| Experimental Runtime | None selected from the three requested candidates | The three analyzed candidates map to active SSOT, secondary operational runtime, and compatibility runtime. Separate corrupted/fixed copies of `full_pipeline_orchestrator` are deprecated lineage artifacts, not requested candidates. | Do not create or nominate an experimental orchestrator. |
+
+## Runtime candidate analysis
+
+### `local_mcp/agent_orchestrator_v3.0.py`
+
+- **Purpose:** V2.3 agent orchestration and compatibility runtime; coordinates six optimized agents and initializes `KnowledgeIntegrationV23`.
+- **Invocation path:** direct script execution in `.github/workflows/v23-cicd.yml`; README “Get Started” also lists `python local_mcp/agent_orchestrator_v3.0.py`.
+- **Dependencies:** dynamically loads `local_mcp/knowledge_integration_v2.3.py`; dynamically loads six files from `local_mcp/agents/` through `_AGENT_CATALOGUE`.
+- **Active references:** README compatibility wrapper, V2.3 workflow, tooling workflow help check, API docs and handover index.
+- **Downstream consumers:** V2.3 agent CI, generated V2.3 artifacts, handover-to-execution bridge documentation.
+- **Baseline decision:** legacy/compatibility runtime, not SSOT.
+
+### `DMAIC_V3/core/twelve_cluster_orchestrator.py`
+
+- **Purpose:** canonical 12-cluster orchestration, temporal phase hooks, cluster contract, optional KEB/GBOGEB runtime integration.
+- **Invocation path:** `python DMAIC_V3/core/twelve_cluster_orchestrator.py --test`; imported by tests; named in README as canonical path.
+- **Dependencies:** optional `KEB` and `GBOGEB`; standard library concurrency; phase task factories supplied by callers.
+- **Active references:** README canonical orchestrator section, migration docs, tests, lineage docs.
+- **Downstream consumers:** tests, runtime reports, consumers requiring the canonical cluster contract and temporal hook events.
+- **Baseline decision:** Active Runtime SSOT.
+
+### `DMAIC_V3/full_pipeline_orchestrator.py`
+
+- **Purpose:** operational DMAIC V3.3 phase pipeline runner for phase 0 initialization through phase 9 documentation generation.
+- **Invocation path:** direct script execution; active DOW workflows run `python DMAIC_V3/full_pipeline_orchestrator.py`; docs show `python DMAIC_V3/full_pipeline_orchestrator.py --iteration ...`.
+- **Dependencies:** `DMAICConfig`, `StateManager`, idempotency wrapper, planning matrix tracker, background change detector, phase modules 0-9.
+- **Active references:** DOW scheduled/main CI workflows, enhanced CI workflow, deployment/handover docs.
+- **Downstream consumers:** workflow runs, reports, `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`, deployment artifacts.
+- **Baseline decision:** Secondary runtime. Retain; do not duplicate.
+
+## Registry SSOT
+
+**Selected registry:** `runtime/manifests/runtime-topology.yaml` for runtime/deployment topology governance.
+
+**Justification:**
+
+- The topology manifest declares the runtime repository, governance repository, protected environments, and runtime capabilities.
+- `metrics/federation/runtime_registry.json` and `reports/runtime_registry_report.json` are evidence/report outputs, not the topology authority.
+- `knowledge_packages/dmaic_core_knowledge.yaml` is the seed knowledge package SSOT for DMAIC knowledge, not a runtime topology registry.
+
+**Evidence:**
+
+- `runtime/manifests/runtime-topology.yaml` defines `runtime.repository: GBOGEB/ABACUS`, governance metadata, capabilities, and protected environments.
+- `metrics/federation/runtime_registry.json` stores repository runtime evidence/truth matrix/renderability status.
+- `reports/runtime_registry_report.json` stores runtime coverage report output.
+- `knowledge_packages/dmaic_core_knowledge.yaml` defines the DMAIC process knowledge package.
+
+## Integration SSOT
+
+### KEB status
+
+- **Status:** PARTIAL but consumed.
+- **Implementation SSOT:** `core/keb/keb.py`.
+- **Consumption adapter:** `local_mcp/knowledge_integration_v2.3.py`.
+- **Evidence:** `KnowledgeIntegrationV23` imports and constructs `KEB`; `TwelveClusterOrchestrator` optionally constructs `KEB`; `.github/workflows/v23-cicd.yml` runs `local_mcp/knowledge_integration_v2.3.py`.
+- **Decision:** retain `core/keb/keb.py`; normalize imports and start/stop expectations before adding features.
+
+### GBOGEB status
+
+- **Status:** PARTIAL but consumed.
+- **Implementation SSOT:** `core/gbogeb/gbogeb.py`.
+- **Bridge candidate:** `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`.
+- **Evidence:** `KnowledgeIntegrationV23` imports and constructs `GBOGEB`; `TwelveClusterOrchestrator` optionally constructs `GBOGEB`; `.github/workflows/gbogeb-abacus-integration-ci-cd.yml` references GBOGEB bridge execution but points at root-level paths.
+- **Decision:** retain `core/gbogeb/gbogeb.py`; fix stale bridge workflow paths before claiming bridge closure.
+
+### DMAIC status
+
+- **Status:** COMPLETE as an operational runtime, with SSOT governance split requiring consolidation.
+- **Execution entrypoints:** `DMAIC_V3/dmaic_v3_engine.py` and `DMAIC_V3/full_pipeline_orchestrator.py`.
+- **Governance SSOT:** `DMAIC_V3/core/twelve_cluster_orchestrator.py`.
+- **Evidence:** CD workflows execute `DMAIC_V3.dmaic_v3_engine`; DOW workflows execute `DMAIC_V3/full_pipeline_orchestrator.py`; README declares 12-cluster orchestrator canonical.
+- **Decision:** retain current operational entrypoints; backlog a workflow alignment task rather than creating new orchestration.
+
+## Validated Gaps
+
+Evidence-backed only:
+
+1. **GBOGEB bridge path drift:** active workflow references root-level `GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`, `test_integration_bridge.py`, and `UNIFIED_GLOB_CONFIG.yaml`, while the bridge implementation found in this repo is `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`.
+2. **Recursive hook retrieval parity:** historical `get_recursive_hooks(enabled_only=True)` is documented, but active runtime modules do not expose a dedicated retrieval API. Current equivalents are artifact-level `recursive_hooks` injection and phase-level temporal registration.
+3. **Runtime entrypoint split:** README declares `TwelveClusterOrchestrator` canonical, while active deployment/DOW workflows still execute `DMAIC_V3.dmaic_v3_engine` and `DMAIC_V3/full_pipeline_orchestrator.py`.
+4. **Integration import inconsistency:** `KnowledgeIntegrationV23` imports `core.keb.keb` and `core.gbogeb.gbogeb`; `TwelveClusterOrchestrator` uses top-level `from keb import KEB` / `from gbogeb import GBOGEB` after path insertion. This is import consolidation work, not a missing component.
+
+## Deferred Work
+
+The following work is explicitly not required for this baseline:
+
+- Building a new orchestrator.
+- Building a new KEB adapter.
+- Building a new GBOGEB connector.
+- Replacing `DOWRecursiveHooksInjector`.
+- Replacing the DMAIC phase runner.
+- Implementing `get_recursive_hooks()` in this task.
+- Moving or deleting workflows in this task.
+
+## Deprecated Targets
+
+Items that should **not** be developed as new architecture:
+
+- A second “Orchestrator V3.0” implementation.
+- A parallel KEB registry separate from `core/keb/keb.py` and `KnowledgeIntegrationV23`.
+- A parallel GBOGEB metrics engine separate from `core/gbogeb/gbogeb.py`.
+- A new recursive hook engine separate from `DMAIC_V3/local_mcp/agents/dow_recursive_hooks_injector.py`.
+- Root-level duplicate GBOGEB bridge files unless the chosen remediation is to promote the existing `staging/` implementation with matching tests/config.
+- Corrupted/fixed duplicate full-pipeline copies as canonical runtime targets.

--- a/ABACUS_FEATURE_LINEAGE.md
+++ b/ABACUS_FEATURE_LINEAGE.md
@@ -1,0 +1,96 @@
+# ABACUS Feature Lineage
+
+Date: 2026-06-11
+
+## Feature lineage matrix
+
+| Feature | V2.2 lineage | V2.3/current location | Status | Confidence | Evidence | Recommendation |
+|---|---|---|---:|---:|---|---|
+| Agent orchestration | Historical orchestrator references and DMAIC agent coordination notes | `local_mcp/agent_orchestrator_v3.0.py` / `AgentOrchestratorV3` | RENAMED | HIGH | `_AGENT_CATALOGUE`, `initialize_agents`, `execute_dmaic_cycle` | retain |
+| DMAIC phase pipeline | Recursive DMAIC engine lineage | `DMAIC_V3/full_pipeline_orchestrator.py` / `FullPipelineOrchestrator` | COMPLETE | HIGH | phase imports and `execute_full_pipeline` | retain |
+| 12-cluster runtime | 12-cluster architecture documents | `DMAIC_V3/core/twelve_cluster_orchestrator.py` / `TwelveClusterOrchestrator` | COMPLETE | HIGH | `CLUSTER_CONTRACT`, `PHASE_SEQUENCE`, `run_phases_with_hooks` | retain |
+| KEB execution backbone | V2.2 KEB template / timeout notes | `core/keb/keb.py` / `KEB`; `KnowledgeIntegrationV23.schedule_agent_task` | PARTIAL | HIGH | core class and knowledge adapter | refactor imports |
+| Knowledge registry | V2.2 knowledge reconciliation and V2.3 preservation docs | `local_mcp/knowledge_integration_v2.3.py`, `knowledge_packages/*`, `ABACUS-UNIFIED/KNOWLEDGE_PACK_INDEX.md` | PARTIAL | HIGH | `KnowledgeEntry`, `_init_knowledge_base`, knowledge package files | retain |
+| Semantic memory / runtime memory | Runtime convergence docs and semantic manifests | `runtime/memory/*.yaml`, `runtime/compiler/semantic-orchestration-compiler.yaml`, `ssot/semantic_traceability.yaml` | PARTIAL | MEDIUM | declarative YAML manifests, no single Python memory connector found | refactor/validate |
+| GBOGEB governance | V2.2 GBOGEB template and timeout notes | `core/gbogeb/gbogeb.py` / `GBOGEB` | PARTIAL | HIGH | metrics/compliance/report APIs | retain |
+| GBOGEB cross-repo bridge | GBOGEB/ABACUS repository lineage | `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`, `.github/workflows/gbogeb-abacus-integration-ci-cd.yml`, RTM project config | PARTIAL | HIGH | bridge class and workflow | replace stale paths |
+| Recursive hook injection | V2.2 recursive hooks | `DMAIC_V3/local_mcp/agents/dow_recursive_hooks_injector.py` | COMPLETE | HIGH | `DOWRecursiveHooksInjector.inject_recursive_hooks` | retain |
+| Recursive hook retrieval | V2.2 API expectation | Not found in active runtime; parity audit records gap | MISSING | HIGH | `PHASE_B_RECURSIVE_HOOKS_PARITY_AUDIT_V4.4.0.md` | add/refactor only if required |
+| Stop/convergence rules | Recursive iteration behavior | `src/dmaic/recursion.py` | COMPLETE | HIGH | `should_stop`, `analyze_convergence`, `generate_stop_rules` | retain |
+| Deployment CI/CD | Earlier CI/CD plans and status reports | `.github/workflows/*.yml`, `DMAIC_V3/.github/workflows/*.yml` | COMPLETE | HIGH | active `on:` triggers | retain |
+
+## Orchestrator feature lineage
+
+### Current symbols
+
+- `local_mcp/agent_orchestrator_v3.0.py`
+  - `AgentOrchestratorV3`
+  - `_AGENT_CATALOGUE`
+  - `initialize_agents`
+  - `execute_agent`
+  - `execute_dmaic_cycle`
+  - `get_agent_status`
+  - `save_results`
+- `DMAIC_V3/full_pipeline_orchestrator.py`
+  - `FullPipelineOrchestrator`
+  - `execute_full_pipeline`
+  - `_generate_phase6_report`
+  - `main`
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py`
+  - `ClusterConfig`
+  - `TwelveClusterOrchestrator`
+  - `execute_phase_parallel`
+  - `run_phases_with_hooks`
+  - `generate_report`
+
+### Lineage determination
+
+Orchestrator V3.0 is not missing. It is split into three named runtime roles: agent orchestration, phase orchestration, and cluster orchestration. Treating these as separate missing systems would create duplicates.
+
+## KEB feature lineage
+
+### Existing adapters and registries
+
+- `core/keb/keb.py` is the execution backbone.
+- `local_mcp/knowledge_integration_v2.3.py` is the adapter that exposes KEB-backed task scheduling to agents.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py` optionally constructs KEB for cluster execution.
+- `orchestrator_config.yaml` configures agent paths and pipeline stages, including DOW recursive hook and convergence agents; KEB worker/memory parameters are constructed in code.
+- `knowledge_packages/dmaic_core_knowledge.*` contains seed knowledge packages.
+- `ABACUS-v032/STATS/DMAIC_FULL/knowledge/**/knowledge_index.json` and `knowledge_packs.json` are generated knowledge registries from previous runs.
+
+### Current status
+
+KEB is PARTIAL because implementation exists but packaging/import boundaries are inconsistent. Do not implement a second KEB adapter; normalize the existing adapter.
+
+## GBOGEB feature lineage
+
+### Existing connectors and references
+
+- `core/gbogeb/gbogeb.py` implements governance metrics and compliance checks.
+- `local_mcp/knowledge_integration_v2.3.py` calls GBOGEB for metric collection and compliance.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py` optionally constructs GBOGEB observability.
+- `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py` is the cross-system DOW bridge.
+- `.github/workflows/gbogeb-abacus-integration-ci-cd.yml` is the CI/CD integration workflow.
+- `rtm_integration/automation/config/project.yml` contains repository cross-links for `GBOGEB/ABACUS` and `GBOGEB/DOCX_RTM_Automation`.
+- `tracking_v2.3/tasks/tasks.json` contains runtime tracking references to `GBOGEB/ABACUS` PRs, action runs, artifacts, and Pages URL.
+
+### Current status
+
+GBOGEB is PARTIAL, not missing. The highest-value next action is to reconcile staging paths with workflow path filters.
+
+## Recursive feature lineage
+
+### V2.2 Feature → V2.3 Equivalent → Current Status
+
+| V2.2 feature | V2.3/current equivalent | Current status | Recommendation |
+|---|---|---:|---|
+| Recursive DMAIC execution | `ABACUS-v032/execute_full_dmaic_phases_0_to_9_v033.py`; `DMAIC_V3/full_pipeline_orchestrator.py` | SUPERSEDED | keep lineage, use current pipeline |
+| Artifact recursive metadata | `DOWRecursiveHooksInjector.inject_recursive_hooks` | COMPLETE | retain |
+| Temporal recursive registration | `Phase6Knowledge.execute` with `register_recursive_hook` | PARTIAL | normalize tracker availability |
+| Stop-rule recursion | `src/dmaic/recursion.py.should_stop` | COMPLETE | retain |
+| Convergence analysis | `src/dmaic/recursion.py.analyze_convergence` and ABACUS-v032 phase 9 reports | COMPLETE | retain |
+| Hook retrieval API | no active `get_recursive_hooks()` found | MISSING | add/read utility if required |
+
+## Deployment feature lineage
+
+Deployment is COMPLETE at the repository level. Active workflows live under `.github/workflows/`. Disabled legacy workflows live under `.github/workflows/legacy/*.old`. Pending/scaffold workflows live under `.github/workflows-pending/`. Additional DMAIC-specific workflows live under `DMAIC_V3/.github/workflows/`.

--- a/ABACUS_GAP_VALIDATION.md
+++ b/ABACUS_GAP_VALIDATION.md
@@ -1,0 +1,133 @@
+# ABACUS Gap Validation — Architectural Lineage Verification
+
+Date: 2026-06-11
+
+## Validation rule
+
+This document validates the requested V2.3/V3.0 gaps before implementation. It treats a gap as missing only when no active code, workflow, runtime manifest, or documented lineage exists. The intent is to avoid duplicate architecture.
+
+## Executive status table
+
+| Gap / capability | Status | Confidence | Primary evidence | Recommendation |
+|---|---:|---:|---|---|
+| Orchestrator V3.0 | RENAMED | HIGH | `local_mcp/agent_orchestrator_v3.0.py` (`AgentOrchestratorV3`), `DMAIC_V3/core/twelve_cluster_orchestrator.py` (`TwelveClusterOrchestrator`), `DMAIC_V3/full_pipeline_orchestrator.py` (`FullPipelineOrchestrator`) | retain + refactor entrypoint naming |
+| KEB integration | PARTIAL | HIGH | `core/keb/keb.py` (`KEB`), `local_mcp/knowledge_integration_v2.3.py` (`KnowledgeIntegrationV23`), `DMAIC_V3/core/twelve_cluster_orchestrator.py` (`KEB_AVAILABLE`, `self.keb`) | retain + refactor imports/packaging |
+| GBOGEB integration | PARTIAL | HIGH | `core/gbogeb/gbogeb.py` (`GBOGEB`), `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py` (`GBOGEBAbacusDOWBridge`), `.github/workflows/gbogeb-abacus-integration-ci-cd.yml` | retain + replace stale workflow paths |
+| Recursive hooks parity | PARTIAL | HIGH | `DMAIC_V3/local_mcp/agents/dow_recursive_hooks_injector.py`, `DMAIC_V3/phases/phase6_knowledge.py`, `src/dmaic/recursion.py`, `PHASE_B_RECURSIVE_HOOKS_PARITY_AUDIT_V4.4.0.md` | retain + add retrieval/query API if needed |
+| Deployment automation | COMPLETE | HIGH | `.github/workflows/*.yml`, `.github/workflows-pending/*.yml`, `.github/workflows/legacy/*.old`, `run_streamlined_deployment.py`, `run_comprehensive_deployment.py` | retain + archive disabled/duplicate workflows |
+
+## Detailed gap records
+
+### 1. Orchestrator V3.0
+
+**Status:** RENAMED  
+**Confidence:** HIGH  
+**Recommendation:** retain the existing orchestrators; refactor documentation and entrypoint naming instead of creating a new orchestrator.
+
+**Determination:** An orchestrator already exists under more than one lineage. The strongest direct match is `local_mcp/agent_orchestrator_v3.0.py`, which defines `AgentOrchestratorV3` and explicitly describes itself as an Agent Orchestrator V3.0 for V2.3 agents. The production DMAIC runtime also has `FullPipelineOrchestrator`, and the parallel/cluster runtime has `TwelveClusterOrchestrator`.
+
+**Evidence:**
+
+- `local_mcp/agent_orchestrator_v3.0.py`: `AgentOrchestratorV3`, `_AGENT_CATALOGUE`, `initialize_agents`, `execute_agent`, `execute_dmaic_cycle`, and `main`.
+- `local_mcp/agent_orchestrator_v3.0.py`: loads `KnowledgeIntegrationV23` before the six V2.3 agents, making it a coordination runtime rather than a placeholder.
+- `orchestrator_config.yaml`: configures agent paths, pipelines, DOW integration stages, `dmaic_phases`, `dow_integration`, and recursive hook/convergence agents.
+- `DMAIC_V3/full_pipeline_orchestrator.py`: `FullPipelineOrchestrator`, `execute_full_pipeline`, and `main` for the DMAIC phase pipeline.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py`: `TwelveClusterOrchestrator`, `CLUSTER_CONTRACT`, `execute_phase_parallel`, and `run_phases_with_hooks`.
+- `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`: imports and instantiates `FullPipelineOrchestrator` for cross-system execution.
+- `deployment_matrix.md`: lists DMAIC V3 Engine, 12-Cluster Orchestrator, CI/CD Orchestrator, and DOW Bridge as working deployment units.
+
+**Duplicate architecture risk:** HIGH if a new “Orchestrator V3.0” is created without first choosing which current runtime is canonical. The correct next action is to define canonical ownership among agent orchestration, DMAIC phase orchestration, and 12-cluster execution.
+
+### 2. KEB integration
+
+**Status:** PARTIAL  
+**Confidence:** HIGH  
+**Recommendation:** retain the current KEB implementation; refactor imports and package boundaries before adding features.
+
+**Determination:** KEB is implemented as a core execution backbone and is referenced by orchestration and knowledge layers. The integration is partial because some code uses top-level imports (`from keb import KEB`) that depend on path manipulation or execution context, while canonical code lives under `core/keb/keb.py`.
+
+**Evidence:**
+
+- `core/keb/keb.py`: `KEB` class provides queued task execution, worker lifecycle, task scheduling, and results tracking.
+- `local_mcp/knowledge_integration_v2.3.py`: `KnowledgeIntegrationV23` initializes `KEB(max_workers=2, max_memory_mb=2048)` and exposes `schedule_agent_task` with timeout protection.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py`: attempts to import `KEB`, gates it through `KEB_AVAILABLE`, and initializes `self.keb` when enabled.
+- `orchestrator_config.yaml`: defines pipeline stages and DOW/recursive integration agents, while KEB runtime parameters are constructed in code (`KEB(max_workers=...)`).
+- `knowledge_packages/dmaic_core_knowledge.yaml` and `knowledge_packages/dmaic_core_knowledge.json`: provide seed knowledge content used by the knowledge lineage.
+- `ABACUS-UNIFIED/KNOWLEDGE_PACK_INDEX.md` and `ABACUS-UNIFIED/books/KNOWLEDGE_MANAGEMENT_BOOK_v032.1.md`: document the knowledge-pack lineage.
+- `DMAIC_V3/phases/phase6_knowledge.py`: implements the Phase 6 knowledge layer and report generation, with recursive hook registration support.
+
+**Hidden integration points:** `KnowledgeIntegrationV23` is invoked by `AgentOrchestratorV3.initialize_agents`, while `TwelveClusterOrchestrator` invokes KEB as an optional execution backbone. This means KEB is not missing; it is split across core, local MCP, and DMAIC runtimes.
+
+**Partiality / risk:** Import resolution is inconsistent (`core/keb/keb.py` versus `from keb import KEB`), so a new adapter should not be created until imports are normalized and package exports are audited.
+
+### 3. GBOGEB integration
+
+**Status:** PARTIAL  
+**Confidence:** HIGH  
+**Recommendation:** retain the current GBOGEB implementation and bridge; replace stale workflow paths and archive superseded references.
+
+**Determination:** GBOGEB exists as a core observability/governance component, bridge implementation, workflow integration, and repository namespace. It is partial because the active workflow points to root-level bridge/test/config paths while the current bridge implementation is under `staging/`.
+
+**Evidence:**
+
+- `core/gbogeb/gbogeb.py`: `GBOGEB` class implements metric collection, compliance checks, report generation, and workspace persistence.
+- `local_mcp/knowledge_integration_v2.3.py`: initializes `GBOGEB` and uses it for metrics and compliance checks through timeout-protected calls.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py`: imports `GBOGEB`, gates it through `GBOGEB_AVAILABLE`, and initializes `self.gbogeb` for observability.
+- `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`: `GBOGEBAbacusDOWBridge` coordinates DOW processing and DMAIC processing, imports `FullPipelineOrchestrator`, and provides `create_unified_glob_config`.
+- `.github/workflows/gbogeb-abacus-integration-ci-cd.yml`: active workflow for “GBOGEB/ABACUS ↔ DOW Integration CI/CD”.
+- `rtm_integration/automation/config/project.yml`: names `GBOGEB/ABACUS` and `GBOGEB/DOCX_RTM_Automation` cross-repository integration targets.
+- `tracking_v2.3/tasks/tasks.json`: stores GitHub links to `GBOGEB/ABACUS` PRs, workflow runs, and pages deployments.
+- `src/dmaic/contract.py`: references `GBOGEB/codespace_jyperter` as tuple-source repository metadata.
+
+**Partiality / risk:** The workflow path filter includes `GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`, `test_integration_bridge.py`, and `UNIFIED_GLOB_CONFIG.yaml` at repository root; the bridge file actually found is `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`. This should be fixed before implementing new GBOGEB connectors.
+
+### 4. Recursive hooks
+
+**Status:** PARTIAL  
+**Confidence:** HIGH  
+**Recommendation:** retain current artifact-level recursive hooks and stop-rule utilities; add/refactor a retrieval API only if consumers require V2.2 API parity.
+
+**Determination:** V2.2-style recursive behavior migrated into multiple current forms: artifact hook injection, phase-level registration, convergence/stop-rule utilities, and 12-cluster temporal hooks. The lost or incomplete portion is a dedicated active `get_recursive_hooks()` retrieval API, already documented as a gap in the parity audit.
+
+**V2.2 → V2.3/current map:**
+
+| V2.2 feature | V2.3 / current equivalent | Current status | Confidence | Recommendation |
+|---|---|---:|---:|---|
+| Recursive DMAIC engine execution | `ABACUS-v032/execute_full_dmaic_phases_0_to_9_v033.py` phase 0-9 runner and `DMAIC_V3/full_pipeline_orchestrator.py` phase runner | SUPERSEDED | HIGH | retain v032 as lineage; use DMAIC_V3 for current runtime |
+| Recursive hooks embedded in artifacts | `DMAIC_V3/local_mcp/agents/dow_recursive_hooks_injector.py` writes `recursive_hooks` payloads | COMPLETE | HIGH | retain |
+| Phase-level hook registration | `DMAIC_V3/phases/phase6_knowledge.py` calls `register_recursive_hook` when temporal tracker is available | PARTIAL | HIGH | retain; normalize tracker import |
+| Iteration stop/convergence rules | `src/dmaic/recursion.py` (`should_stop`, `analyze_convergence`, `generate_stop_rules`) | COMPLETE | HIGH | retain |
+| Temporal start/end hooks per phase | `DMAIC_V3/core/twelve_cluster_orchestrator.py` (`run_phases_with_hooks`, `_record_temporal_event`) | RENAMED | HIGH | retain |
+| Dedicated `get_recursive_hooks()` API | Not found in active runtime; documented by parity audit as missing | MISSING | HIGH | refactor/add lightweight read utility if needed |
+
+**Evidence:**
+
+- `PHASE_B_RECURSIVE_HOOKS_PARITY_AUDIT_V4.4.0.md`: concludes recursive hooks are actively injected and validated, but a historical `get_recursive_hooks` API is not present in active runtime modules.
+- `DMAIC_V3/local_mcp/agents/dow_recursive_hooks_injector.py`: `DOWRecursiveHooksInjector.inject_recursive_hooks` writes `recursive_hooks` fields with hook metadata, dependency chain, validation rules, and idempotency fields.
+- `DMAIC_V3/phases/phase6_knowledge.py`: `Phase6Knowledge.execute` attempts temporal tracker hook registration and records `recursive_hooks_registered` in outputs.
+- `src/dmaic/recursion.py`: provides reusable stop and convergence analysis functions.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py`: `run_phases_with_hooks` records standardized phase start/end events.
+- `.github/workflows/dow-integration.yml`: invokes DOW integration activities; `.github/workflows/recursive-build.yml` provides recursive build automation.
+
+### 5. Deployment
+
+**Status:** COMPLETE  
+**Confidence:** HIGH  
+**Recommendation:** retain active workflows, reconcile duplicate CI/CD names, and archive disabled or pending scaffolds.
+
+**Determination:** CI and deployment workflows are present and active. There are also pending and legacy workflow locations that should not be treated as missing implementation.
+
+**Evidence:**
+
+- Active workflow directory: `.github/workflows/` contains CI, CD, release, docs deployment, pages, runtime governance, runtime verification, DOW, GBOGEB, recursive build, and validation workflows.
+- Disabled/archived workflow directory: `.github/workflows/legacy/` contains `.old` workflow files.
+- Pending/scaffold workflow directory: `.github/workflows-pending/` contains workflow files plus a catalog that describes 37 active workflows and separates pending documentation.
+- Nested DMAIC workflows: `DMAIC_V3/.github/workflows/` contains `DMAIC_V3/.github/workflows/ci-main.yml`, `DMAIC_V3/.github/workflows/cd-main.yml`, phase CI workflows, and `DMAIC_V3/.github/workflows/release.yml`.
+- Deployment scripts: `run_streamlined_deployment.py`, `run_comprehensive_deployment.py`, `abacus_v21_deployment_execution.py`, `ci_cd_automation.ps1`, and `setup_github.sh`.
+- Release pipelines: `.github/workflows/release.yml`, `.github/workflows/delta-1-release.yml`, `.github/workflows/cd-unified.yml`, and `DMAIC_V3/.github/workflows/release.yml`.
+
+**Active versus disabled:** Active GitHub Actions are files directly under `.github/workflows/` with `on:` triggers. Legacy disabled files are retained under `.github/workflows/legacy/*.old`. Pending/scaffold workflows exist under `.github/workflows-pending/` and should not be counted as active GitHub Actions until moved into `.github/workflows/`.
+
+## Final recommendation
+
+Do not implement new architecture for any of the above categories yet. The repository already contains orchestrators, KEB, GBOGEB, recursive hooks, and deployment automation. The next safe work is consolidation: pick canonical entrypoints, normalize package imports, repair stale workflow paths, and document supported runtime paths.

--- a/ABACUS_INTEGRATION_MATRIX.md
+++ b/ABACUS_INTEGRATION_MATRIX.md
@@ -1,0 +1,43 @@
+# ABACUS Integration Matrix
+
+Date: 2026-06-11
+
+## Scope
+
+This matrix checks runtime **consumption**, not merely existence. The components below are treated as consumed only when repository code, workflows, tests, or configuration invoke or reference them as part of an execution path.
+
+## Consumption matrix
+
+| Component | Exists | Referenced | Executed | SSOT |
+| --------- | ------ | ---------- | -------- | ---- |
+| KEB | Yes: `core/keb/keb.py` defines `KEB` and `schedule_task`. | Yes: `local_mcp/knowledge_integration_v2.3.py` imports `core.keb.keb.KEB`; `DMAIC_V3/core/twelve_cluster_orchestrator.py` imports `KEB`; README maps C9-C10 runtime operations to `local_mcp/knowledge_integration_v2.3.py`. | Partial: `KnowledgeIntegrationV23` constructs `KEB(max_workers=2, max_memory_mb=2048)` and exposes `schedule_agent_task`; `TwelveClusterOrchestrator` constructs KEB when `KEB_AVAILABLE`; `.github/workflows/v23-cicd.yml` executes `python local_mcp/knowledge_integration_v2.3.py`. | Implementation SSOT: `core/keb/keb.py`; consumption adapter: `local_mcp/knowledge_integration_v2.3.py`. |
+| GBOGEB | Yes: `core/gbogeb/gbogeb.py` defines `GBOGEB`, `collect_metric`, and `check_compliance`. | Yes: `local_mcp/knowledge_integration_v2.3.py` imports `core.gbogeb.gbogeb.GBOGEB`; `DMAIC_V3/core/twelve_cluster_orchestrator.py` imports `GBOGEB`; `.github/workflows/gbogeb-abacus-integration-ci-cd.yml` references the GBOGEB bridge. | Partial: `KnowledgeIntegrationV23` constructs `GBOGEB`; `TwelveClusterOrchestrator` constructs GBOGEB when `GBOGEB_AVAILABLE`; bridge workflow references root-level bridge path while implementation found under `staging/`. | Implementation SSOT: `core/gbogeb/gbogeb.py`; bridge candidate: `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py` pending workflow path reconciliation. |
+| DMAIC | Yes: `DMAIC_V3/dmaic_v3_engine.py`, `DMAIC_V3/full_pipeline_orchestrator.py`, and `DMAIC_V3/phases/`. | Yes: `.github/workflows/cd.yml` and `.github/workflows/cd-unified.yml` run `python -m DMAIC_V3.dmaic_v3_engine`; DOW workflows run `DMAIC_V3/full_pipeline_orchestrator.py`; README marks `DMAIC_V3/core/twelve_cluster_orchestrator.py` canonical. | Yes: active workflows execute DMAIC engine/full pipeline commands; tests cover `TwelveClusterOrchestrator`. | Runtime governance SSOT: `DMAIC_V3/core/twelve_cluster_orchestrator.py`; operational workflow entrypoints remain `DMAIC_V3/dmaic_v3_engine.py` and `DMAIC_V3/full_pipeline_orchestrator.py` until consolidated. |
+| Agents | Yes: `local_mcp/agents/*_v2.3_OPTIMIZED.py` and `DMAIC_V3/agents/`. | Yes: `local_mcp/agent_orchestrator_v3.0.py` `_AGENT_CATALOGUE`; `orchestrator_config.yaml` DOW integration agents; `.github/workflows/v23-cicd.yml` tests the V2.3 orchestrator and smoke agent. | Partial: V2.3 workflow executes `local_mcp/agent_orchestrator_v3.0.py`, `local_mcp/knowledge_integration_v2.3.py`, and one smoke agent; DOW executor calls DOW agents by name. | Agent catalogue SSOT: `local_mcp/agent_orchestrator_v3.0.py` for V2.3 compatibility; DOW agent routing SSOT: `orchestrator_config.yaml` plus `DMAIC_V3/dow_integration_executor.py`. |
+
+## Evidence details
+
+### KEB consumption
+
+- `local_mcp/knowledge_integration_v2.3.py` imports `KEB` from `core.keb.keb` and `GBOGEB` from `core.gbogeb.gbogeb`.
+- `KnowledgeIntegrationV23.__init__` constructs `KEB(max_workers=2, max_memory_mb=2048)` and `GBOGEB(workspace=...)` when core modules are available.
+- `KnowledgeIntegrationV23.schedule_agent_task` calls `self.keb.schedule_task(...)` through timeout protection.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py` imports `KEB`, sets `KEB_AVAILABLE`, and constructs `KEB(max_workers=min(max_workers, 4), max_memory_mb=2048)` when enabled.
+
+### GBOGEB consumption
+
+- `KnowledgeIntegrationV23.collect_agent_metric` calls `self.gbogeb.collect_metric(...)`.
+- `KnowledgeIntegrationV23.check_compliance` calls `self.gbogeb.check_compliance(...)`.
+- `DMAIC_V3/core/twelve_cluster_orchestrator.py` constructs `GBOGEB(workspace="DMAIC_V3_OUTPUT/12cluster_workspace")` when enabled.
+- `.github/workflows/gbogeb-abacus-integration-ci-cd.yml` references root-level `GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`, while the located implementation is `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py`; therefore bridge execution is not closed.
+
+### DMAIC and agent consumption
+
+- `.github/workflows/cd.yml` and `.github/workflows/cd-unified.yml` run `python -m DMAIC_V3.dmaic_v3_engine --mode full --iterations 1`.
+- `.github/workflows/dow-scheduled.yml` and `.github/workflows/dow-main-cicd.yml` run `python DMAIC_V3/full_pipeline_orchestrator.py`.
+- `.github/workflows/v23-cicd.yml` runs `python local_mcp/agent_orchestrator_v3.0.py`, `python local_mcp/knowledge_integration_v2.3.py`, and a V2.3 smoke agent.
+- `DMAIC_V3/tests/test_twelve_cluster_orchestrator.py` imports and verifies `TwelveClusterOrchestrator` contract, parallel execution, temporal hooks, and timeout behavior.
+
+## Integration conclusion
+
+KEB and GBOGEB are consumed, but the consumption is **partial** because execution paths are split across `KnowledgeIntegrationV23`, optional 12-cluster initialization, and a GBOGEB workflow that points at stale root-level bridge paths. No new integration layer should be created; the next work is import/path consolidation and bridge workflow correction.

--- a/ABACUS_MAIN_LINEAGE.md
+++ b/ABACUS_MAIN_LINEAGE.md
@@ -1,0 +1,97 @@
+# ABACUS Main Architectural Lineage
+
+Date: 2026-06-11
+
+## Purpose
+
+This lineage record maps the main ABACUS runtime architecture before new implementation work begins. Its central conclusion is that the requested V2.3/V3.0 capabilities are not absent; they are distributed across historical, current, and staging paths.
+
+## Mainline lineage graph
+
+```text
+V2.1 / V2.2 recursive DMAIC artifacts
+  ├─ recursive_dmaic_engine lineage documented in V2.2 status/handover files
+  ├─ KEB/GBOGEB templates and timeout notes documented in session quick references
+  └─ recursive behavior expectations captured in recursive hook parity documents
+        ↓
+V2.3 agent and knowledge integration layer
+  ├─ local_mcp/agent_orchestrator_v3.0.py
+  ├─ local_mcp/knowledge_integration_v2.3.py
+  ├─ local_mcp/agents/*_v2.3_OPTIMIZED.py
+  └─ orchestrator_config.yaml
+        ↓
+DMAIC_V3 production pipeline and 12-cluster runtime
+  ├─ DMAIC_V3/full_pipeline_orchestrator.py
+  ├─ DMAIC_V3/core/twelve_cluster_orchestrator.py
+  ├─ DMAIC_V3/phases/phase0_init.py ... phase9_documentation.py
+  ├─ core/keb/keb.py
+  └─ core/gbogeb/gbogeb.py
+        ↓
+ABACUS-v032 / v4.4 lineage and runtime manifests
+  ├─ ABACUS-v032/execute_full_dmaic_phases_0_to_9_v033.py
+  ├─ runtime/**/*.yaml
+  ├─ reports/runtime_registry_report.json
+  └─ metrics/federation/runtime_registry.json
+        ↓
+Deployment / CI/CD layer
+  ├─ .github/workflows/*.yml
+  ├─ .github/workflows/legacy/*.old
+  ├─ .github/workflows-pending/*.yml
+  └─ DMAIC_V3/.github/workflows/*.yml
+```
+
+## Canonical runtime candidates
+
+| Runtime candidate | File path | Exact symbol / entrypoint | Role | Status | Confidence | Recommendation |
+|---|---|---|---|---:|---:|---|
+| V2.3 Agent Orchestrator V3.0 | `local_mcp/agent_orchestrator_v3.0.py` | `AgentOrchestratorV3`, `initialize_agents`, `execute_dmaic_cycle`, `main` | Loads six V2.3 agents and knowledge integration | RENAMED | HIGH | retain; document as agent orchestration layer |
+| DMAIC V3 full pipeline | `DMAIC_V3/full_pipeline_orchestrator.py` | `FullPipelineOrchestrator`, `execute_full_pipeline`, `main` | Current phase pipeline runner | COMPLETE | HIGH | retain as DMAIC pipeline entrypoint |
+| 12-cluster orchestration | `DMAIC_V3/core/twelve_cluster_orchestrator.py` | `TwelveClusterOrchestrator`, `CLUSTER_CONTRACT`, `run_phases_with_hooks` | Parallel cluster/temporal hook runtime | COMPLETE | HIGH | retain; mark as cluster execution layer |
+| DOW/GBOGEB bridge | `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py` | `GBOGEBAbacusDOWBridge`, `execute_integrated_pipeline` | Cross-system bridge between DOW, DMAIC, and GBOGEB namespace | PARTIAL | HIGH | retain; promote or update workflow paths |
+| Runtime manifest plane | `runtime/` | YAML manifests such as `runtime/manifests/runtime-topology.yaml` | Declarative runtime topology and governance plane | PARTIAL | MEDIUM | retain; validate against code entrypoints |
+
+## Evidence basis
+
+The lineage evidence is organized below by concern and uses exact repository paths, symbols, workflows, and configuration references.
+
+## Mainline evidence by concern
+
+### Orchestration
+
+- The V3.0 agent orchestrator exists as `AgentOrchestratorV3` and explicitly coordinates V2.3 optimized agents.
+- The DMAIC V3 runtime exists as `FullPipelineOrchestrator`, which executes phase modules and writes execution artifacts.
+- The 12-cluster runtime exists as `TwelveClusterOrchestrator`, with a static cluster contract, optional KEB/GBOGEB integration, and phase hooks.
+- The DOW/GBOGEB bridge imports `FullPipelineOrchestrator` and invokes it during integrated execution.
+
+### Knowledge and KEB
+
+- `KnowledgeIntegrationV23` is the current knowledge integration adapter. It initializes canonical knowledge entries and bridges KEB/GBOGEB calls.
+- `core/keb/keb.py` is the execution backbone implementation.
+- Knowledge packages and ABACUS-UNIFIED knowledge books preserve the non-code lineage.
+
+### Governance and GBOGEB
+
+- `core/gbogeb/gbogeb.py` is the local governance/observability implementation.
+- The GBOGEB namespace appears in repository metadata, workflows, RTM automation config, and tracking JSON.
+- `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py` is the active bridge implementation found in the tree, but its workflow path filters still reference root-level paths.
+
+### Recursion
+
+- V2.2 recursive expectations survived as artifact injection, temporal events, phase-level registration, and stop/convergence utilities.
+- A direct `get_recursive_hooks()` runtime retrieval function was not found and is therefore the only validated missing recursive API surface.
+
+### Deployment
+
+- `.github/workflows/` is populated with active workflows.
+- `.github/workflows/legacy/` and `.github/workflows-pending/` show archived/pending workflow lineages rather than missing deployment work.
+- `DMAIC_V3/.github/workflows/` adds nested project workflows.
+
+## Duplicate architecture elimination decision
+
+No new orchestrator, KEB adapter, GBOGEB connector, recursive hook engine, or deployment pipeline should be created until the following refactor-only tasks are complete:
+
+1. Declare canonical entrypoints for agent orchestration, DMAIC pipeline execution, and 12-cluster execution.
+2. Normalize KEB/GBOGEB imports so `core/keb/keb.py` and `core/gbogeb/gbogeb.py` can be imported consistently.
+3. Update `gbogeb-abacus-integration-ci-cd.yml` path filters or promote the staging bridge to the expected path.
+4. Add or document a recursive hook retrieval/read API only if current consumers require V2.2 parity.
+5. Archive or label duplicate workflow families to reduce CI ambiguity.

--- a/ABACUS_RUNTIME_INVENTORY.md
+++ b/ABACUS_RUNTIME_INVENTORY.md
@@ -1,0 +1,86 @@
+# ABACUS Runtime Inventory
+
+Date: 2026-06-11
+
+## Inventory scope
+
+This file inventories runtime code, configuration, workflows, and manifests relevant to Orchestrator V3.0, KEB, GBOGEB, recursive hooks, and deployment automation.
+
+## Evidence basis
+
+Inventory evidence includes exact runtime file paths, symbols, configuration files, workflow paths, and deployment scripts.
+
+## Runtime code inventory
+
+| Runtime area | Path | Exact symbol / reference | Role | Status | Confidence | Recommendation |
+|---|---|---|---|---:|---:|---|
+| Agent orchestrator | `local_mcp/agent_orchestrator_v3.0.py` | `AgentOrchestratorV3` | Coordinates six V2.3 agents and knowledge integration | RENAMED | HIGH | retain |
+| Agent catalog | `local_mcp/agent_orchestrator_v3.0.py` | `_AGENT_CATALOGUE` | Maps logical agent names to optimized V2.3 files/classes | COMPLETE | HIGH | retain |
+| Knowledge integration | `local_mcp/knowledge_integration_v2.3.py` | `KnowledgeIntegrationV23`, `KnowledgeEntry` | Unified KEB/GBOGEB knowledge layer | PARTIAL | HIGH | refactor imports |
+| KEB core | `core/keb/keb.py` | `KEB`, `_PriorityTask` | Priority execution backbone | PARTIAL | HIGH | retain |
+| GBOGEB core | `core/gbogeb/gbogeb.py` | `GBOGEB` | Metrics, compliance, and governance reports | PARTIAL | HIGH | retain |
+| DMAIC full pipeline | `DMAIC_V3/full_pipeline_orchestrator.py` | `FullPipelineOrchestrator` | DMAIC V3 phase orchestration | COMPLETE | HIGH | retain |
+| 12-cluster orchestrator | `DMAIC_V3/core/twelve_cluster_orchestrator.py` | `TwelveClusterOrchestrator` | Parallel cluster runtime and temporal phase hooks | COMPLETE | HIGH | retain |
+| DOW recursive hook injector | `DMAIC_V3/local_mcp/agents/dow_recursive_hooks_injector.py` | `DOWRecursiveHooksInjector` | Injects recursive metadata into artifacts | COMPLETE | HIGH | retain |
+| Phase 6 knowledge | `DMAIC_V3/phases/phase6_knowledge.py` | `Phase6Knowledge`, `KnowledgeReference` | Knowledge devour/reporting and hook registration | PARTIAL | HIGH | retain |
+| Recursion utilities | `src/dmaic/recursion.py` | `should_stop`, `analyze_convergence`, `generate_stop_rules` | Stop/convergence analysis | COMPLETE | HIGH | retain |
+| Federation utilities | `src/dmaic/federation.py` | `assimilate` | Federation assimilation stub for runtime plane | PARTIAL | MEDIUM | retain |
+| GBOGEB/DOW bridge | `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py` | `GBOGEBAbacusDOWBridge` | Cross-system bridge | PARTIAL | HIGH | replace stale workflow paths |
+| CI/CD orchestrator | `cicd_github_orchestrator.py` | script entrypoint | GitHub CI/CD automation | PARTIAL | MEDIUM | retain if still used |
+| DOW deployment orchestrator | `DOW_DEPLOYMENT_ORCHESTRATOR.py` | script entrypoint | DOW deployment orchestration | PARTIAL | MEDIUM | retain/validate |
+
+## Configuration and registry inventory
+
+| Path | Reference | Role | Status | Recommendation |
+|---|---|---|---:|---|
+| `orchestrator_config.yaml` | `agents`, `pipelines`, `dow_integration`, `dmaic_phases` | Main pipeline/orchestrator configuration | COMPLETE | retain |
+| `knowledge_packages/dmaic_core_knowledge.yaml` | knowledge package content | Seed knowledge registry | COMPLETE | retain |
+| `knowledge_packages/dmaic_core_knowledge.json` | knowledge package content | JSON mirror of seed registry | COMPLETE | retain |
+| `metrics/federation/runtime_registry.json` | runtime registry data | Federation runtime registry | PARTIAL | validate |
+| `reports/runtime_registry_report.json` | runtime registry report | Runtime publication/reporting evidence | PARTIAL | validate |
+| `runtime/manifests/runtime-topology.yaml` | runtime topology | Declarative runtime plane | PARTIAL | validate against code |
+| `runtime/manifests/recursive-orchestration-dag.yaml` | recursive orchestration DAG | Recursive runtime declaration | PARTIAL | validate against code |
+| `runtime/memory/governance-memory-registry.yaml` | memory registry | Semantic/operational memory registry | PARTIAL | validate connector ownership |
+| `ssot/semantic_traceability.yaml` | traceability registry | Semantic traceability | PARTIAL | retain |
+| `rtm_integration/automation/config/project.yml` | `GBOGEB/ABACUS`, `GBOGEB/DOCX_RTM_Automation` | RTM project/repository registry | COMPLETE | retain |
+| `tracking_v2.3/tasks/tasks.json` | GitHub PR/action/artifact/page URLs | V2.3 runtime tracking evidence | COMPLETE | retain |
+
+## Active workflow inventory
+
+Files directly under `.github/workflows/` are active GitHub Actions definitions when they contain `on:` triggers. Key categories found:
+
+| Category | Workflow paths | Status | Recommendation |
+|---|---|---:|---|
+| Core CI | `.github/workflows/ci.yml`, `.github/workflows/ci-abacus.yml`, `.github/workflows/ci-codex.yml`, `.github/workflows/ci-enhanced.yml`, `.github/workflows/main.yml`, `.github/workflows/abacus-cicd.yml` | COMPLETE | retain; reduce overlap later |
+| CD/deployment | `.github/workflows/cd.yml`, `.github/workflows/cd-unified.yml`, `.github/workflows/deployment-enforcement.yml`, `.github/workflows/delta-1-deploy.yml` | COMPLETE | retain |
+| Release | `.github/workflows/release.yml`, `.github/workflows/delta-1-release.yml` | COMPLETE | retain |
+| Docs/pages deployment | `.github/workflows/deploy-docs.yml`, `.github/workflows/pages.yml`, `.github/workflows/update-docs.yml`, `.github/workflows/export-docs.yml`, `.github/workflows/book-build.yml` | COMPLETE | retain |
+| Runtime governance | `.github/workflows/runtime-governance.yml`, `.github/workflows/runtime-verification.yml`, `.github/workflows/runtime-smoke.yml`, `.github/workflows/governance.yml`, `.github/workflows/governance-drift-detection.yml` | COMPLETE | retain |
+| DOW/GBOGEB | `.github/workflows/dow-integration.yml`, `.github/workflows/dow-main-cicd.yml`, `.github/workflows/dow-monitoring.yml`, `.github/workflows/dow-scheduled.yml`, `.github/workflows/gbogeb-abacus-integration-ci-cd.yml` | PARTIAL | update GBOGEB bridge paths |
+| Recursive | `.github/workflows/recursive-build.yml` | COMPLETE | retain |
+| Security | `.github/workflows/codeql.yml`, `.github/workflows/dependency-review.yml`, `.github/workflows/reusable-security.yml` | COMPLETE | retain |
+| Validation/quality | `.github/workflows/format-check.yml`, `.github/workflows/validate_docs.yml`, `.github/workflows/validation.yml`, `.github/workflows/yaml-validation.yml`, `.github/workflows/smoke-test.yml`, `.github/workflows/tooling-ci.yml`, `.github/workflows/validate-setup.yml` | COMPLETE | retain |
+| Monitoring/reporting | `.github/workflows/dashboard-health.yml`, `.github/workflows/ci_monitor_and_issue_creator.yml`, `.github/workflows/reports.yml`, `.github/workflows/inventory.yml`, `.github/workflows/dmaic-commit-metrics.yml` | COMPLETE | retain |
+
+## Disabled, pending, and nested workflow inventory
+
+| Location | Contents | Active? | Status | Recommendation |
+|---|---|---:|---:|---|
+| `.github/workflows/legacy/` | `.github/workflows/legacy/cd.yml.old`, `.github/workflows/legacy/dow-integration-ci-cd.yml.old` | No | SUPERSEDED | archive |
+| `.github/workflows-pending/` | `.github/workflows-pending/deploy-docs.yml`, `.github/workflows-pending/release.yml`, `.github/workflows-pending/update-docs.yml`, dashboard and metrics scaffolds | No | PARTIAL | move only after validation |
+| `DMAIC_V3/.github/workflows/` | `DMAIC_V3/.github/workflows/ci-main.yml`, `DMAIC_V3/.github/workflows/cd-main.yml`, phase CI workflows, `DMAIC_V3/.github/workflows/release.yml` | Nested project workflows | PARTIAL | validate if intended to run at repo root |
+
+## Deployment script inventory
+
+| Path | Role | Status | Recommendation |
+|---|---|---:|---|
+| `run_streamlined_deployment.py` | streamlined deployment runner | PARTIAL | validate |
+| `run_comprehensive_deployment.py` | comprehensive deployment runner | PARTIAL | validate |
+| `abacus_v21_deployment_execution.py` | V2.1 deployment execution and health checks | SUPERSEDED | archive or retain as lineage |
+| `abacus_v21_postdeployment_validation.py` | post-deployment validation | SUPERSEDED | archive or retain as lineage |
+| `ci_cd_automation.ps1` | PowerShell CI/CD automation | PARTIAL | validate current use |
+| `setup_github.sh` | GitHub setup helper | PARTIAL | validate current use |
+
+## Runtime inventory conclusion
+
+The repo already contains the requested runtime capabilities. The remaining gaps are consolidation gaps, not greenfield implementation gaps: normalize imports, fix stale workflow path filters, document canonical entrypoints, and add a recursive hook read utility only if consumers need V2.2 parity.

--- a/tracking_v2.3/tasks/TASK_recursive_hook_parity.yaml
+++ b/tracking_v2.3/tasks/TASK_recursive_hook_parity.yaml
@@ -1,0 +1,32 @@
+requirement: >-
+  Close V2.2 recursive hook retrieval parity by adding or documenting an active
+  read path equivalent to get_recursive_hooks(enabled_only=True) without
+  replacing the current artifact-level recursive_hooks injection model.
+status: missing
+owner: Runtime governance / DMAIC_V3 maintainers
+priority: P1
+created: '2026-06-11'
+evidence:
+  historical_expectation:
+    - file: V2.2_RECURSIVE_HOOKS_VERSION_ALIGNMENT.md
+      reference: 'lines 62-73 define get_recursive_hooks(enabled_only=True) retrieval capabilities.'
+  current_gap:
+    - file: PHASE_B_RECURSIVE_HOOKS_PARITY_AUDIT_V4.4.0.md
+      reference: 'lines 20-32 mark the dedicated get_recursive_hooks retrieval API as not found in active DMAIC_V3/local_mcp/src runtime modules.'
+  current_equivalents:
+    - file: DMAIC_V3/local_mcp/agents/dow_recursive_hooks_injector.py
+      reference: 'DOWRecursiveHooksInjector.inject_recursive_hooks writes recursive_hooks into artifact JSON.'
+    - file: DMAIC_V3/phases/phase6_knowledge.py
+      reference: 'Phase6Knowledge.execute registers a recursive hook through temporal_tracker when available and reports recursive_hooks_registered.'
+non_goals:
+  - Do not create a new recursive hook engine.
+  - Do not replace DOWRecursiveHooksInjector.
+  - Do not duplicate temporal tracker registration.
+acceptance_criteria:
+  - Active code or documentation exposes a deterministic retrieval path for artifact-level recursive_hooks.
+  - Retrieval path is covered by a test or validation script that reads an artifact with recursive_hooks.
+  - Existing DOWRecursiveHooksInjector behavior remains the source of artifact hook metadata.
+  - ABACUS_GAP_VALIDATION.md and ABACUS_EXECUTION_BASELINE.md are updated to mark retrieval parity closed only after evidence exists.
+dependencies:
+  - Runtime SSOT remains DMAIC_V3/core/twelve_cluster_orchestrator.py.
+  - Recursive hook metadata remains artifact-level unless a future approved task changes the model.


### PR DESCRIPTION
### Motivation

- Capture and consolidate architecture, runtime, integration, deployment, and feature-lineage findings into a documented baseline to avoid duplicate implementation and clarify canonical entrypoints. 
- Surface evidence-backed gaps (notably GBOGEB bridge path drift and missing `get_recursive_hooks()` parity) and prescribe consolidation-first next steps such as import normalization and workflow path fixes. 
- Record runtime and registry SSOT decisions to guide governance and prevent uncoordinated new orchestrator/connector development. 

### Description

- Add a set of repository-first documentation files: `ABACUS_DEPLOYMENT_STATUS.md`, `ABACUS_EXECUTION_BACKLOG.md`, `ABACUS_EXECUTION_BASELINE.md`, `ABACUS_FEATURE_LINEAGE.md`, `ABACUS_GAP_VALIDATION.md`, `ABACUS_INTEGRATION_MATRIX.md`, `ABACUS_MAIN_LINEAGE.md`, and `ABACUS_RUNTIME_INVENTORY.md` that enumerate evidence, decisions, and recommended next actions. 
- Declare `DMAIC_V3/core/twelve_cluster_orchestrator.py` as the runtime governance SSOT, mark `DMAIC_V3/full_pipeline_orchestrator.py` as the secondary operational runtime, and retain `local_mcp/agent_orchestrator_v3.0.py` as a compatibility runtime in the baseline. 
- Highlight specific consolidation work: normalize `KEB`/`GBOGEB` imports, reconcile `staging/GBOGEB_ABACUS_DOW_INTEGRATION_BRIDGE.py` with workflow path filters, and add a documented task to close recursive hook retrieval parity. 
- Add `tracking_v2.3/tasks/TASK_recursive_hook_parity.yaml` to track the P1 task to provide parity for `get_recursive_hooks(enabled_only=True)` with acceptance criteria and dependencies. 

### Testing

- No runtime code or unit tests were modified in this PR, so no unit test changes were required. 
- New documentation and the task YAML were validated with basic syntax checks, and `yamllint`/`markdownlint` style checks were run against the added files and passed. 
- Repository CI was not changed by these docs-only additions and therefore existing CI behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a99e2c114832ea257443c0df3da0a)